### PR TITLE
Add build to Installation steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,9 @@ Code ChatGPT Plugin is a TypeScript Code Analyzer that provides a set of utiliti
 1. Clone the repository: `git clone https://github.com/kesor/chatgpt-code-plugin.git`
 2. Navigate to the project directory: `cd chatgpt-code-plugin`
 3. Install the dependencies: `npm install`
-4. Start the server: `BASE_PATH=/home/myuser/src/awesome-project  npm start`
-5. Add the API into ChatGPT Plus plugins' "Developer your own plugin" interface (`http://localhost:3000`)
+4. Build project: `npm run buid`
+5. Start the server: `BASE_PATH=/home/myuser/src/awesome-project  npm start`
+6. Add the API into ChatGPT Plus plugins' "Developer your own plugin" interface (`http://localhost:3000`)
 
 ## Usage
 


### PR DESCRIPTION
`npm start` depends on the project being built, so that `/dist` exists.

Added the needed step in the installation instructions.